### PR TITLE
Add Coinbase exchange support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,9 @@ config*.json
 *.sqlite-wal
 logfile.txt
 user_data/*
+!user_data/strategies/
 !user_data/strategy/sample_strategy.py
+!user_data/strategies/SmaCrossStrategy.py
 !user_data/notebooks
 !user_data/models
 !user_data/freqaimodels
@@ -114,5 +116,6 @@ target/
 !config_examples/config_full.example.json
 !config_examples/config_kraken.example.json
 !config_examples/config_freqai.example.json
+!config_examples/config_coinbase.example.json
 
 docker-compose-*.yml

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Please read the [exchange specific notes](docs/exchanges.md) to learn about even
 - [X] [HTX](https://www.htx.com/)
 - [X] [Hyperliquid](https://hyperliquid.xyz/) (A decentralized exchange, or DEX)
 - [X] [Kraken](https://kraken.com/)
+- [X] [Coinbase](https://www.coinbase.com/)
 - [X] [OKX](https://okx.com/)
 - [X] [MyOKX](https://okx.com/) (OKX EEA)
 - [ ] [potentially many others](https://github.com/ccxt/ccxt/). _(We cannot guarantee they will work)_
@@ -79,9 +80,9 @@ Please find the complete documentation on the [freqtrade website](https://www.fr
 
 ## Quick start
 
+This repository is streamlined for Docker usage.
 Please refer to the [Docker Quickstart documentation](https://www.freqtrade.io/en/stable/docker_quickstart/) on how to get started quickly.
-
-For further (native) installation methods, please refer to the [Installation documentation page](https://www.freqtrade.io/en/stable/installation/).
+An example strategy called `SmaCrossStrategy` is included in `user_data/strategies` to help you get started immediately.
 
 ## Basic Usage
 

--- a/config_examples/config_coinbase.example.json
+++ b/config_examples/config_coinbase.example.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://schema.freqtrade.io/schema.json",
+    "max_open_trades": 3,
+    "stake_currency": "USD",
+    "stake_amount": 30,
+    "tradable_balance_ratio": 0.99,
+    "fiat_display_currency": "USD",
+    "timeframe": "5m",
+    "dry_run": true,
+    "exchange": {
+        "name": "coinbase",
+        "key": "your_exchange_key",
+        "secret": "your_exchange_secret",
+        "ccxt_config": {},
+        "ccxt_async_config": {},
+        "pair_whitelist": ["BTC/USD", "ETH/USD"],
+        "pair_blacklist": ["BEAR/.*"],
+    },
+    "pairlists": [{"method": "StaticPairList"}],
+    "telegram": {
+        "enabled": false,
+        "token": "your_telegram_token",
+        "chat_id": "your_telegram_chat_id",
+    },
+    "bot_name": "freqtrade",
+}

--- a/docs/exchanges.md
+++ b/docs/exchanges.md
@@ -407,6 +407,10 @@ If your account is required to use an operatorId, you can set it in the configur
 
 Bitvavo expects the `operatorId` to be an integer.
 
+## Coinbase
+
+Coinbase uses the Advanced Trade API. Make sure your API keys have trading permissions enabled.
+
 ## All exchanges
 
 Should you experience constant errors with Nonce (like `InvalidNonce`), it is best to regenerate the API keys. Resetting Nonce is difficult and it's usually easier to regenerate the API keys.

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -10,6 +10,7 @@ from freqtrade.exchange.bitmart import Bitmart
 from freqtrade.exchange.bitpanda import Bitpanda
 from freqtrade.exchange.bitvavo import Bitvavo
 from freqtrade.exchange.bybit import Bybit
+from freqtrade.exchange.coinbase import Coinbase
 from freqtrade.exchange.cryptocom import Cryptocom
 from freqtrade.exchange.exchange_utils import (
     ROUND_DOWN,

--- a/freqtrade/exchange/coinbase.py
+++ b/freqtrade/exchange/coinbase.py
@@ -1,0 +1,20 @@
+"""Coinbase exchange subclass."""
+
+import logging
+
+from freqtrade.exchange import Exchange
+from freqtrade.exchange.exchange_types import FtHas
+
+
+logger = logging.getLogger(__name__)
+
+
+class Coinbase(Exchange):
+    """Coinbase exchange class.
+
+    Contains adjustments needed for Freqtrade to work with this exchange.
+    """
+
+    _ft_has: FtHas = {
+        "ohlcv_volume_currency": "quote",
+    }

--- a/freqtrade/exchange/common.py
+++ b/freqtrade/exchange/common.py
@@ -62,6 +62,7 @@ SUPPORTED_EXCHANGES = [
     "gate",
     "htx",
     "hyperliquid",
+    "coinbase",
     "kraken",
     "okx",
 ]

--- a/user_data/strategies/SmaCrossStrategy.py
+++ b/user_data/strategies/SmaCrossStrategy.py
@@ -1,0 +1,31 @@
+import talib.abstract as ta
+from pandas import DataFrame
+
+from freqtrade.strategy import IStrategy
+
+
+class SmaCrossStrategy(IStrategy):
+    """Simple SMA cross strategy."""
+
+    minimal_roi = {"0": 0.01}
+    stoploss = -0.10
+    timeframe = "5m"
+
+    def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe["sma_short"] = ta.SMA(dataframe["close"], timeperiod=20)
+        dataframe["sma_long"] = ta.SMA(dataframe["close"], timeperiod=50)
+        return dataframe
+
+    def populate_entry_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[
+            (dataframe["sma_short"] > dataframe["sma_long"]),
+            "enter_long",
+        ] = 1
+        return dataframe
+
+    def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
+        dataframe.loc[
+            (dataframe["sma_short"] < dataframe["sma_long"]),
+            "exit_long",
+        ] = 1
+        return dataframe


### PR DESCRIPTION
## Summary
- add Coinbase exchange implementation
- list Coinbase as supported exchange
- add sample SMA cross strategy
- note Docker-only quickstart
- add Coinbase example config

## Testing
- `ruff check freqtrade/exchange/__init__.py freqtrade/exchange/coinbase.py user_data/strategies/SmaCrossStrategy.py`
- `mypy freqtrade/exchange/coinbase.py user_data/strategies/SmaCrossStrategy.py` *(fails: No module named 'sqlalchemy')*
- `pytest tests/test_exchange.py::test_available_exchanges` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_688cf6c4db3c8329b79670150db6754e